### PR TITLE
Add additional find illness test

### DIFF
--- a/src/main/java/seedu/address/model/person/IllnessContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/IllnessContainsKeywordsPredicate.java
@@ -29,6 +29,27 @@ public class IllnessContainsKeywordsPredicate implements Predicate<Person> {
                 });
     }
 
+    private boolean areStringListsEqualCaseInsensitive(List<String> keywords1, List<String> keywords2) {
+        // Check if both lists have the same size
+        if (keywords1.size() != keywords2.size()) {
+            return false;
+        }
+
+        // Iterate through the elements and compare them in a case-insensitive manner
+        for (int i = 0; i < keywords1.size(); i++) {
+            String str1 = keywords1.get(i);
+            String str2 = keywords2.get(i);
+
+            // Use equalsIgnoreCase for case-insensitive comparison
+            if (!str1.equalsIgnoreCase(str2)) {
+                return false;
+            }
+        }
+
+        // If all elements are equal, return true
+        return true;
+    }
+
     @Override
     public boolean equals(Object other) {
         if (other == this) {
@@ -42,7 +63,7 @@ public class IllnessContainsKeywordsPredicate implements Predicate<Person> {
 
         IllnessContainsKeywordsPredicate otherIllnessContainsKeywordsPredicate =
                 (IllnessContainsKeywordsPredicate) other;
-        return keywords.equals(otherIllnessContainsKeywordsPredicate.keywords);
+        return areStringListsEqualCaseInsensitive(keywords, otherIllnessContainsKeywordsPredicate.keywords);
     }
 
     @Override

--- a/src/test/java/seedu/address/logic/commands/personcommands/FindIllnessCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/personcommands/FindIllnessCommandTest.java
@@ -9,6 +9,7 @@ import static seedu.address.testutil.TypicalPersons.getTypicalAddressBookWithIll
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
@@ -23,13 +24,24 @@ public class FindIllnessCommandTest {
 
     @Test
     public void equals() {
+        List<String> firstPredicateKeywordList = Collections.singletonList("first");
+        List<String> secondPredicateKeywordList = Arrays.asList("first", "second");
+        List<String> firstPredicateKeywordListUpperCase = Collections.singletonList("FIRST");
+        List<String> firstPredicateKeywordListMixedCase = Collections.singletonList("FiRsT");
+
         IllnessContainsKeywordsPredicate firstPredicate =
-                new IllnessContainsKeywordsPredicate(Collections.singletonList("fever"));
+                new IllnessContainsKeywordsPredicate(firstPredicateKeywordList);
         IllnessContainsKeywordsPredicate secondPredicate =
-                new IllnessContainsKeywordsPredicate(Collections.singletonList("headache"));
+                new IllnessContainsKeywordsPredicate(secondPredicateKeywordList);
+        IllnessContainsKeywordsPredicate firstPredicateUpperCase =
+                new IllnessContainsKeywordsPredicate(firstPredicateKeywordListUpperCase);
+        IllnessContainsKeywordsPredicate firstPredicateMixedCase =
+                new IllnessContainsKeywordsPredicate(firstPredicateKeywordListMixedCase);
 
         FindIllnessCommand findIllnessFirstCommand = new FindIllnessCommand(firstPredicate);
         FindIllnessCommand findIllnessSecondCommand = new FindIllnessCommand(secondPredicate);
+        FindIllnessCommand findIllnessFirstCommandUpperCasePredicate = new FindIllnessCommand(firstPredicateUpperCase);
+        FindIllnessCommand findIllnessFirstCommandMixedCasePredicate = new FindIllnessCommand(firstPredicateMixedCase);
 
         // same object -> returns true
         assertTrue(findIllnessFirstCommand.equals(findIllnessFirstCommand));
@@ -44,8 +56,14 @@ public class FindIllnessCommandTest {
         // null -> returns false
         assertFalse(findIllnessFirstCommand.equals(null));
 
-        // different person -> returns false
+        // different predicate -> returns false
         assertFalse(findIllnessFirstCommand.equals(findIllnessSecondCommand));
+
+        // predicate with same keywords but one upper case and another lower case -> returns true
+        assertTrue(findIllnessFirstCommand.equals(findIllnessFirstCommandUpperCasePredicate));
+
+        // predicate with same keywords but one mixed case and another lower case -> returns true
+        assertTrue(findIllnessFirstCommand.equals(findIllnessFirstCommandMixedCasePredicate));
     }
 
     @Test
@@ -59,6 +77,15 @@ public class FindIllnessCommandTest {
     }
 
     @Test
+    public void execute_singleKeyword_singleIllnessFound() {
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 1);
+        IllnessContainsKeywordsPredicate predicate = preparePredicate("FEVER");
+        FindIllnessCommand command = new FindIllnessCommand(predicate);
+        expectedModel.updateFilteredPersonList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+    }
+
+    @Test
     public void execute_multipleKeywords_multipleIllnessFound() {
         String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 3);
         IllnessContainsKeywordsPredicate predicate = preparePredicate("FEVER HEADACHE APPENDICITIS");
@@ -67,6 +94,25 @@ public class FindIllnessCommandTest {
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
     }
 
+    @Test
+    public void execute_partialKeyword_singleIllnessFound() {
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 1);
+        // Note: the keyword 'fev' should still identify someone with 'fever'
+        IllnessContainsKeywordsPredicate predicate = preparePredicate("fev");
+        FindIllnessCommand command = new FindIllnessCommand(predicate);
+        expectedModel.updateFilteredPersonList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_wrongKeyword_noIllnessFound() {
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0);
+        // Note: typing the keyword 'FEVAR' instead of 'FEVER' will yield no result
+        IllnessContainsKeywordsPredicate predicate = preparePredicate("FEVAR");
+        FindIllnessCommand command = new FindIllnessCommand(predicate);
+        expectedModel.updateFilteredPersonList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+    }
 
     private IllnessContainsKeywordsPredicate preparePredicate(String userInput) {
         return new IllnessContainsKeywordsPredicate(Arrays.asList(userInput.split("\\s+")));

--- a/src/test/java/seedu/address/model/person/IllnessContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/IllnessContainsKeywordsPredicateTest.java
@@ -16,11 +16,17 @@ public class IllnessContainsKeywordsPredicateTest {
     public void equals() {
         List<String> firstPredicateKeywordList = Collections.singletonList("first");
         List<String> secondPredicateKeywordList = Arrays.asList("first", "second");
+        List<String> firstPredicateKeywordListUpperCase = Collections.singletonList("FIRST");
+        List<String> firstPredicateKeywordListMixedCase = Collections.singletonList("FiRsT");
 
         IllnessContainsKeywordsPredicate firstPredicate =
                 new IllnessContainsKeywordsPredicate(firstPredicateKeywordList);
         IllnessContainsKeywordsPredicate secondPredicate =
                 new IllnessContainsKeywordsPredicate(secondPredicateKeywordList);
+        IllnessContainsKeywordsPredicate firstPredicateUpperCase =
+                new IllnessContainsKeywordsPredicate(firstPredicateKeywordListUpperCase);
+        IllnessContainsKeywordsPredicate firstPredicateMixedCase =
+                new IllnessContainsKeywordsPredicate(firstPredicateKeywordListMixedCase);
 
         // same object -> returns true
         assertTrue(firstPredicate.equals(firstPredicate));
@@ -38,6 +44,12 @@ public class IllnessContainsKeywordsPredicateTest {
 
         // different illness -> returns false
         assertFalse(firstPredicate.equals(secondPredicate));
+
+        // same values but Upper Case - Same predicate since keywords are meant to be case-insensitive
+        assertTrue(firstPredicate.equals(firstPredicateUpperCase));
+
+        // same values but Mixed Case - Same predicate since keywords are meant to be case-insensitive
+        assertTrue(firstPredicate.equals(firstPredicateMixedCase));
     }
 
     @Test
@@ -55,8 +67,24 @@ public class IllnessContainsKeywordsPredicateTest {
         predicate = new IllnessContainsKeywordsPredicate(Arrays.asList("fever", "headache"));
         assertTrue(predicate.test(new PersonBuilder().withTags("fever appendicitis").build()));
 
-        // Mixed-case keywords
+        // Keywords that make part of the illness (Keyword 'flu' should return patients with 'influenza' too)
+        predicate = new IllnessContainsKeywordsPredicate(Arrays.asList("flu"));
+        assertTrue(predicate.test(new PersonBuilder().withTags("influenza").build()));
+
+        // Keywords with Cases Mixed - Test for Case Insensitivity
         predicate = new IllnessContainsKeywordsPredicate(Arrays.asList("fEvEr", "HEADache"));
         assertTrue(predicate.test(new PersonBuilder().withTags("fever headache").build()));
+    }
+
+    @Test
+    public void test_illnessDoesNotContainKeywords_returnsFalse() {
+        // Keywords do not match any illness
+        IllnessContainsKeywordsPredicate predicate = new IllnessContainsKeywordsPredicate(Arrays.asList("fever", "headache"));
+        assertFalse(predicate.test(new PersonBuilder().withTags("flu appendicitis").build()));
+
+        // Typo in keyword leads to false result
+        predicate = new IllnessContainsKeywordsPredicate(Collections
+                .singletonList("fevar"));
+        assertFalse(predicate.test(new PersonBuilder().withTags("fever").build()));
     }
 }

--- a/src/test/java/seedu/address/model/person/IllnessContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/IllnessContainsKeywordsPredicateTest.java
@@ -79,7 +79,8 @@ public class IllnessContainsKeywordsPredicateTest {
     @Test
     public void test_illnessDoesNotContainKeywords_returnsFalse() {
         // Keywords do not match any illness
-        IllnessContainsKeywordsPredicate predicate = new IllnessContainsKeywordsPredicate(Arrays.asList("fever", "headache"));
+        IllnessContainsKeywordsPredicate predicate =
+                new IllnessContainsKeywordsPredicate(Arrays.asList("fever", "headache"));
         assertFalse(predicate.test(new PersonBuilder().withTags("flu appendicitis").build()));
 
         // Typo in keyword leads to false result


### PR DESCRIPTION
Modified the testing of the equals method for IllnessContainsKeywordsPredicate to be more accurate. Predicates are compared with each other in a case-insensitive manner now. 